### PR TITLE
Remove the style on line 637

### DIFF
--- a/style.css
+++ b/style.css
@@ -634,7 +634,7 @@ footer .social-links {
   /*=== HOME =================================*/
   #home {
     padding-top: var(--nav-height);
-    height: 100vh;
+/*     height: 100vh; */
     padding-block: 16rem;
   }
 


### PR DESCRIPTION
Notei que a altura da #home estava fixa à altura da viewport (desktop), fazendo com que o conteúdo de .wrapper pulasse para fora conforme se diminuía a altura da tela (100vh) e se embolasse com a seção dos serviços.
Sinta-se à vontade para modificar estas alterações (deixei a alteração apenas comentada para evitar qualquer coisa) ou mesmo rejeitá-las caso haja algum bug que eu não tenha percebido. Sou um mero iniciante na programação e vi se pude colaborar de algum jeito.
Seu projeto tá muito massa, parabéns.

Abaixo vai um vídeo que gravei a modificação no DevTools pra exemplificar melhor.
[Rocketseat - Google Chrome 2022-05-16 11-58-05.zip](https://github.com/Livia-CA/Rocketseat/files/8701275/Rocketseat.-.Google.Chrome.2022-05-16.11-58-05.zip)